### PR TITLE
Update condor_worker.conf

### DIFF
--- a/osg/files/condor/condor_worker.conf
+++ b/osg/files/condor/condor_worker.conf
@@ -18,3 +18,4 @@ NUM_SLOTS                 = 1
 NUM_SLOTS_TYPE_1          = 1
 SlotWeight                = Cpus
 
+DEFAULT_DOMAIN_NAME       = pace.gatech.edu


### PR DESCRIPTION
adding default_domain_name value to 99-condor-worker.conf so that we can remotely call condor_off -peaceful on compute nodes from osg-sched